### PR TITLE
Field Capabilities api

### DIFF
--- a/jest-common/src/main/java/io/searchbox/fields/FieldCaps.java
+++ b/jest-common/src/main/java/io/searchbox/fields/FieldCaps.java
@@ -1,0 +1,57 @@
+package io.searchbox.fields;
+
+import io.searchbox.action.AbstractAction;
+import io.searchbox.action.GenericResultAbstractAction;
+import io.searchbox.client.config.ElasticsearchVersion;
+import io.searchbox.params.Parameters;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class FieldCaps extends GenericResultAbstractAction {
+    protected FieldCaps(FieldCaps.Builder builder) {
+        super(builder);
+
+        this.indexName = builder.index;
+
+        Map<String, Object> fieldStatsBody = new HashMap<>();
+        fieldStatsBody.put("fields", builder.fields);
+
+        this.payload = fieldStatsBody;
+    }
+
+    @Override
+    public String getRestMethodName() {
+        return "POST";
+    }
+
+    @Override
+    protected String buildURI(ElasticsearchVersion elasticsearchVersion) {
+        String buildURI = super.buildURI(elasticsearchVersion);
+        if (buildURI.isEmpty())
+            return "_field_caps";
+
+        return buildURI + "/_field_caps";
+    }
+
+
+    public static class Builder extends AbstractAction.Builder<FieldCaps, FieldCaps.Builder> {
+
+        private String index;
+        private Object fields;
+
+        public Builder(Object fields) {
+            this.fields = fields;
+        }
+
+        public FieldCaps.Builder setIndex(String index) {
+            this.index = index;
+            return this;
+        }
+
+        @Override
+        public FieldCaps build() {
+            return new FieldCaps(this);
+        }
+    }
+}

--- a/jest-common/src/test/java/io/searchbox/fields/FieldsCapsTest.java
+++ b/jest-common/src/test/java/io/searchbox/fields/FieldsCapsTest.java
@@ -1,0 +1,32 @@
+package io.searchbox.fields;
+
+import com.google.gson.Gson;
+import io.searchbox.client.config.ElasticsearchVersion;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class FieldsCapsTest {
+    static final String TEST_FIELD = "test_name";
+    static final String INDEX = "twitter";
+    static final List FIELDS = Collections.singletonList(TEST_FIELD);
+
+    @Test
+    public void testBasicUriGeneration() {
+        FieldCaps fieldCaps = new FieldCaps.Builder(FIELDS).setIndex(INDEX).build();
+        assertEquals("POST", fieldCaps.getRestMethodName());
+        assertEquals(INDEX + "/_field_caps", fieldCaps.getURI(ElasticsearchVersion.V55));
+        assertEquals("{\"fields\":[\"" + TEST_FIELD + "\"]}", fieldCaps.getData(new Gson()));
+    }
+
+    @Test
+    public void testBasicUriGenerationNoIndex() {
+        FieldCaps fieldCaps = new FieldCaps.Builder(FIELDS).build();
+        assertEquals("POST", fieldCaps.getRestMethodName());
+        assertEquals("_field_caps", fieldCaps.getURI(ElasticsearchVersion.V55));
+        assertEquals("{\"fields\":[\"" + TEST_FIELD + "\"]}", fieldCaps.getData(new Gson()));
+    }
+}


### PR DESCRIPTION
Enable Elastic's _field_caps api
Relevant for elastic 5.4+ due to "_field_stats" api depreciation