### PR TITLE
Gson stream size limit

### DIFF
--- a/jest-common/pom.xml
+++ b/jest-common/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>io.searchbox</groupId>
         <artifactId>jest-parent</artifactId>
-        <version>6.3.1-Logzio-3</version>
+        <version>6.3.1-Logzio-4</version>
     </parent>
 
     <dependencies>

--- a/jest-droid/pom.xml
+++ b/jest-droid/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>io.searchbox</groupId>
         <artifactId>jest-parent</artifactId>
-        <version>6.3.1-Logzio-3</version>
+        <version>6.3.1-Logzio-4</version>
     </parent>
 
     <dependencies>

--- a/jest/pom.xml
+++ b/jest/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>io.searchbox</groupId>
         <artifactId>jest-parent</artifactId>
-        <version>6.3.1-Logzio-3</version>
+        <version>6.3.1-Logzio-4</version>
     </parent>
 
     <dependencies>

--- a/jest/pom.xml
+++ b/jest/pom.xml
@@ -119,6 +119,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>

--- a/jest/src/main/java/io/searchbox/client/http/JestHttpClient.java
+++ b/jest/src/main/java/io/searchbox/client/http/JestHttpClient.java
@@ -1,16 +1,20 @@
 package io.searchbox.client.http;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import io.searchbox.action.Action;
 import io.searchbox.client.AbstractJestClient;
 import io.searchbox.client.JestResult;
 import io.searchbox.client.JestResultHandler;
 import io.searchbox.client.config.ElasticsearchVersion;
 import io.searchbox.client.config.exception.CouldNotConnectException;
+import io.searchbox.client.http.apache.ContentLengthLimitedInputStream;
 import io.searchbox.client.http.apache.HttpDeleteWithEntity;
 import io.searchbox.client.http.apache.HttpGetWithEntity;
-import org.apache.http.ContentTooLongException;
+import io.searchbox.core.MultiSearch;
+import io.searchbox.core.MultiSearchResult;
 import org.apache.http.Header;
+import org.apache.http.HttpEntity;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
@@ -34,6 +38,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.util.Map.Entry;
 import java.util.concurrent.Future;
 
@@ -83,27 +89,44 @@ public class JestHttpClient extends AbstractJestClient {
         }
     }
 
-    public <T extends JestResult> T execute(Action<T> clientRequest, RequestConfig requestConfig, long contentLengthLimit) throws IOException {
+    public MultiSearchResult execute(MultiSearch clientRequest, RequestConfig requestConfig, int contentLengthLimit) throws IOException {
         HttpUriRequest request = prepareRequest(clientRequest, requestConfig);
         CloseableHttpResponse response = null;
+        ContentLengthLimitedInputStream lengthLimitedInputStream = null;
+        Reader lengthLimitedInputStreamReader = null;
         try {
             response = executeRequest(request);
-            Header contentLengthHeader = response.getFirstHeader("Content-Length");
-            if (contentLengthHeader != null) {
-                String contentLengthHeaderValue = contentLengthHeader.getValue();
-                try {
-                    long contentLength = Long.parseLong(contentLengthHeaderValue);
-                    if (contentLength >= contentLengthLimit) {
-                        throw new ContentTooLongException(String.format("Response body size of %d exceeds set limit of %d", contentLength, contentLengthLimit));
-                    }
-                } catch (NumberFormatException e) {
-                    log.warn(String.format("Content-Length contains invalid number: %s", contentLengthHeaderValue), e);
+            StatusLine statusLine = response.getStatusLine();
+            int statusCode = statusLine.getStatusCode();
+            String reasonPhrase = statusLine.getReasonPhrase();
+
+            HttpEntity entity = response.getEntity();
+            lengthLimitedInputStream = new ContentLengthLimitedInputStream(entity.getContent(), contentLengthLimit);
+            lengthLimitedInputStreamReader = new InputStreamReader(lengthLimitedInputStream);
+            JsonObject result = gson.fromJson(lengthLimitedInputStreamReader, JsonObject.class);
+
+            MultiSearchResult multiSearchResult = new MultiSearchResult(gson);
+            multiSearchResult.setResponseCode(statusCode);
+            multiSearchResult.setJsonString(result.toString());
+            multiSearchResult.setJsonObject(result);
+            multiSearchResult.setPathToResult(null);
+
+            if (isHttpSuccessful(statusCode)) {
+                multiSearchResult.setSucceeded(true);
+                log.debug("Request and operation succeeded");
+            } else {
+                multiSearchResult.setSucceeded(false);
+                if (multiSearchResult.getErrorMessage() == null) {
+                    multiSearchResult.setErrorMessage(statusCode + " " + (reasonPhrase == null ? "null" : reasonPhrase));
                 }
+                log.debug("Response is failed. errorMessage is " + multiSearchResult.getErrorMessage());
             }
-            return deserializeResponse(response, request, clientRequest);
+            return multiSearchResult;
         } catch (HttpHostConnectException ex) {
             throw new CouldNotConnectException(ex.getHost().toURI(), ex);
         } finally {
+            if (lengthLimitedInputStream != null) lengthLimitedInputStream.close();
+            if (lengthLimitedInputStreamReader != null) lengthLimitedInputStreamReader.close();
             if (response != null) {
                 try {
                     response.close();
@@ -112,6 +135,10 @@ public class JestHttpClient extends AbstractJestClient {
                 }
             }
         }
+    }
+
+    private boolean isHttpSuccessful(int httpCode) {
+        return (httpCode / 100) == 2;
     }
 
     @Override

--- a/jest/src/main/java/io/searchbox/client/http/JestHttpClient.java
+++ b/jest/src/main/java/io/searchbox/client/http/JestHttpClient.java
@@ -18,6 +18,7 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
 import org.apache.http.StatusLine;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.entity.EntityBuilder;
@@ -138,7 +139,7 @@ public class JestHttpClient extends AbstractJestClient {
     }
 
     private boolean isHttpSuccessful(int httpCode) {
-        return (httpCode / 100) == 2;
+        return httpCode >= HttpStatus.SC_OK && httpCode < HttpStatus.SC_MULTIPLE_CHOICES;
     }
 
     @Override

--- a/jest/src/main/java/io/searchbox/client/http/apache/ContentLengthLimitedInputStream.java
+++ b/jest/src/main/java/io/searchbox/client/http/apache/ContentLengthLimitedInputStream.java
@@ -1,0 +1,24 @@
+package io.searchbox.client.http.apache;
+
+import org.apache.commons.io.input.CountingInputStream;
+import org.apache.http.ContentTooLongException;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class ContentLengthLimitedInputStream extends CountingInputStream {
+
+    private final int contentLengthLimit;
+
+    public ContentLengthLimitedInputStream(InputStream in, int contentLengthLimit) {
+        super(in);
+        this.contentLengthLimit = contentLengthLimit;
+    }
+
+    @Override
+    protected void beforeRead(int n) throws IOException {
+        if (this.getByteCount() >= contentLengthLimit)
+            throw new ContentTooLongException("ES response exceeds allowed limit");
+        super.beforeRead(n);
+    }
+}

--- a/jest/src/main/java/io/searchbox/client/http/apache/ContentLengthLimitedInputStream.java
+++ b/jest/src/main/java/io/searchbox/client/http/apache/ContentLengthLimitedInputStream.java
@@ -17,8 +17,8 @@ public class ContentLengthLimitedInputStream extends CountingInputStream {
 
     @Override
     protected void beforeRead(int n) throws IOException {
-        if (this.getByteCount() >= contentLengthLimit)
-            throw new ContentTooLongException("ES response exceeds allowed limit");
+        if (this.getByteCount() > contentLengthLimit)
+            throw new ContentTooLongException("ES response exceeds allowed limit of " + contentLengthLimit + " bytes");
         super.beforeRead(n);
     }
 }

--- a/jest/src/test/java/io/searchbox/client/http/ContentLengthLimitedInputStreamTest.java
+++ b/jest/src/test/java/io/searchbox/client/http/ContentLengthLimitedInputStreamTest.java
@@ -1,0 +1,33 @@
+package io.searchbox.client.http;
+
+import io.searchbox.client.http.apache.ContentLengthLimitedInputStream;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.ContentTooLongException;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+
+import static org.junit.Assert.assertEquals;
+
+public class ContentLengthLimitedInputStreamTest {
+
+    @Test
+    public void contentLimitedInputStream() throws IOException {
+        // 57 bytes
+        String initialString = "this should be too long and throw ContentTooLongException";
+        InputStream targetStream = IOUtils.toInputStream(initialString, Charset.defaultCharset());
+        ContentLengthLimitedInputStream contentLengthLimitedInputStream = new ContentLengthLimitedInputStream(targetStream, 57);
+        String afterStream = IOUtils.toString(contentLengthLimitedInputStream, Charset.defaultCharset());
+        assertEquals(initialString, afterStream);
+    }
+
+    @Test(expected = ContentTooLongException.class)
+    public void contentLimitedInputStreamShouldThrowIfTooLong() throws IOException {
+        String initialString = "this should be too long and throw ContentTooLongException";
+        InputStream targetStream = IOUtils.toInputStream(initialString, Charset.defaultCharset());
+        ContentLengthLimitedInputStream contentLengthLimitedInputStream = new ContentLengthLimitedInputStream(targetStream, 5);
+        IOUtils.toString(contentLengthLimitedInputStream, Charset.defaultCharset());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.searchbox</groupId>
     <artifactId>jest-parent</artifactId>
     <packaging>pom</packaging>
-    <version>6.3.1-Logzio-3</version>
+    <version>6.3.1-Logzio-4</version>
     <name>Jest Parent POM</name>
     <description>Parent POM for Jest - ElasticSearch Java rest client</description>
     <url>https://github.com/searchbox-io/Jest</url>
@@ -249,7 +249,7 @@
             <dependency>
                 <groupId>io.searchbox</groupId>
                 <artifactId>jest-common</artifactId>
-                <version>6.3.1-Logzio-3</version>
+                <version>6.3.1-Logzio-4</version>
             </dependency>
 
             <!-- Testing Dependencies -->


### PR DESCRIPTION
I think this is the best we can do without significant refactoring of a bunch of code. I don't think we can avoid having duplicates of responses in-memory because of how `MultiSearchResult` is built (it expects both the json object and string)