### PR TITLE
Fix java.lang.UnsupportedOperationException: JsonNull in percentile aggs

### DIFF
--- a/jest-common/pom.xml
+++ b/jest-common/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>io.searchbox</groupId>
         <artifactId>jest-parent</artifactId>
-        <version>6.3.1-Logzio-12</version>
+        <version>6.3.1-Logzio-13</version>
     </parent>
 
     <dependencies>

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/PercentilesAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/PercentilesAggregation.java
@@ -1,6 +1,7 @@
 package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 
 import java.util.HashMap;
@@ -14,6 +15,7 @@ public class PercentilesAggregation extends MetricAggregation {
 
     public static final String TYPE = "percentiles";
 
+    private JsonNull jsonNull = JsonNull.INSTANCE;
     private Map<String, Double> percentiles = new HashMap<String, Double>();
 
     public PercentilesAggregation(String name, JsonObject percentilesAggregation) {
@@ -23,7 +25,8 @@ public class PercentilesAggregation extends MetricAggregation {
 
     private void parseSource(JsonObject source) {
         for (Map.Entry<String, JsonElement> entry : source.entrySet()) {
-            if(!(Double.isNaN(entry.getValue().getAsDouble()))) {
+            // In case of no results, in Elasticsearch the behaviour was to get 'NaN' and in OpenSearch is 'null'
+            if(!entry.getValue().equals(jsonNull) && !(Double.isNaN(entry.getValue().getAsDouble()))) {
                 percentiles.put(entry.getKey(), entry.getValue().getAsDouble());
             }
         }

--- a/jest-droid/pom.xml
+++ b/jest-droid/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>io.searchbox</groupId>
         <artifactId>jest-parent</artifactId>
-        <version>6.3.1-Logzio-12</version>
+        <version>6.3.1-Logzio-13</version>
     </parent>
 
     <dependencies>

--- a/jest/pom.xml
+++ b/jest/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>io.searchbox</groupId>
         <artifactId>jest-parent</artifactId>
-        <version>6.3.1-Logzio-12</version>
+        <version>6.3.1-Logzio-13</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.searchbox</groupId>
     <artifactId>jest-parent</artifactId>
     <packaging>pom</packaging>
-    <version>6.3.1-Logzio-12</version>
+    <version>6.3.1-Logzio-13</version>
     <name>Jest Parent POM</name>
     <description>Parent POM for Jest - ElasticSearch Java rest client</description>
     <url>https://github.com/searchbox-io/Jest</url>


### PR DESCRIPTION
Since we added the percentile aggregation we keep getting UnsupportedOperationException in case of the field we try to aggregate on is missing. This fix should fix these errors.